### PR TITLE
Use relative paths

### DIFF
--- a/templates/datatablesScripts.ejs
+++ b/templates/datatablesScripts.ejs
@@ -1,14 +1,14 @@
-<script src="/static/plugins/ep_tables2/static/js/datatables-renderer.js"></script>
+<script src="../static/plugins/ep_tables2/static/js/datatables-renderer.js"></script>
 <script type="text/javascript">
 	require.define("datatables-renderer", function(require, exports, module) { exports.DatatablesRenderer = DatatablesRenderer; });
 </script>
 
-<script  src="/static/plugins/ep_tables2/static/js/yahoo_2.8.0/yahoo-dom-event/yahoo-dom-event.js"></script>
-<script  src="/static/plugins/ep_tables2/static/js/yahoo_2.8.0/dragdrop/dragdrop-min.js"></script>
-<script  src="/static/plugins/ep_tables2/static/js/yahoo_2.8.0/slider/slider-min.js"></script>
-<script  src="/static/plugins/ep_tables2/static/js/yahoo_2.8.0/element/element-min.js"></script>
-<script  src="/static/plugins/ep_tables2/static/js/yahoo_2.8.0/colorpicker/colorpicker-min.js"></script>
-<script  src="/static/plugins/ep_tables2/static/js/yahoo_2.8.0/container/container_core-min.js"></script>
-<script  src="/static/plugins/ep_tables2/static/js/yahoo_2.8.0/menu/menu-min.js"></script>
-<script  src="/static/plugins/ep_tables2/static/js/yahoo_2.8.0/button/button-min.js"></script>
-<script  src="/static/plugins/ep_tables2/static/js/yahoo_2.8.0/container/container-min.js"></script> 
+<script  src="../static/plugins/ep_tables2/static/js/yahoo_2.8.0/yahoo-dom-event/yahoo-dom-event.js"></script>
+<script  src="../static/plugins/ep_tables2/static/js/yahoo_2.8.0/dragdrop/dragdrop-min.js"></script>
+<script  src="../static/plugins/ep_tables2/static/js/yahoo_2.8.0/slider/slider-min.js"></script>
+<script  src="../static/plugins/ep_tables2/static/js/yahoo_2.8.0/element/element-min.js"></script>
+<script  src="../static/plugins/ep_tables2/static/js/yahoo_2.8.0/colorpicker/colorpicker-min.js"></script>
+<script  src="../static/plugins/ep_tables2/static/js/yahoo_2.8.0/container/container_core-min.js"></script>
+<script  src="../static/plugins/ep_tables2/static/js/yahoo_2.8.0/menu/menu-min.js"></script>
+<script  src="../static/plugins/ep_tables2/static/js/yahoo_2.8.0/button/button-min.js"></script>
+<script  src="../static/plugins/ep_tables2/static/js/yahoo_2.8.0/container/container-min.js"></script>

--- a/templates/datatablesScriptsTimeslider.ejs
+++ b/templates/datatablesScriptsTimeslider.ejs
@@ -1,1 +1,1 @@
-<script src="/static/plugins/ep_tables2/static/js/datatables-renderer.js"></script>
+<script src="../static/plugins/ep_tables2/static/js/datatables-renderer.js"></script>

--- a/templates/styles.ejs
+++ b/templates/styles.ejs
@@ -1,9 +1,9 @@
 
-<link rel='stylesheet' href='/static/plugins/ep_tables2/static/js/yahoo_2.8.0/fonts/fonts-min.css' type='text/css' />	
-<link rel='stylesheet' href='/static/plugins/ep_tables2/static/js/yahoo_2.8.0/slider/assets/skins/sam/slider.css' type='text/css' />	
-<link rel='stylesheet' href='/static/plugins/ep_tables2/static/js/yahoo_2.8.0/button/assets/skins/sam/button.css' type='text/css' />	
-<link rel='stylesheet' href='/static/plugins/ep_tables2/static/js/yahoo_2.8.0/menu/assets/skins/sam/menu.css' type='text/css' />
-<link rel='stylesheet' href='/static/plugins/ep_tables2/static/js/yahoo_2.8.0/container/assets/skins/sam/container.css' type='text/css' />
-<link rel='stylesheet' href='/static/plugins/ep_tables2/static/js/yahoo_2.8.0/colorpicker/assets/skins/sam/colorpicker.css' type='text/css' />
+<link rel='stylesheet' href='../static/plugins/ep_tables2/static/js/yahoo_2.8.0/fonts/fonts-min.css' type='text/css' />
+<link rel='stylesheet' href='../static/plugins/ep_tables2/static/js/yahoo_2.8.0/slider/assets/skins/sam/slider.css' type='text/css' />
+<link rel='stylesheet' href='../static/plugins/ep_tables2/static/js/yahoo_2.8.0/button/assets/skins/sam/button.css' type='text/css' />
+<link rel='stylesheet' href='../static/plugins/ep_tables2/static/js/yahoo_2.8.0/menu/assets/skins/sam/menu.css' type='text/css' />
+<link rel='stylesheet' href='../static/plugins/ep_tables2/static/js/yahoo_2.8.0/container/assets/skins/sam/container.css' type='text/css' />
+<link rel='stylesheet' href='../static/plugins/ep_tables2/static/js/yahoo_2.8.0/colorpicker/assets/skins/sam/colorpicker.css' type='text/css' />
 
-<link rel="stylesheet" href="/static/plugins/ep_tables2/static/css/data-tbl-menu.css" type="text/css" />
+<link rel="stylesheet" href="../static/plugins/ep_tables2/static/css/data-tbl-menu.css" type="text/css" />


### PR DESCRIPTION
This makes plugin work when Etherpad is not installed under `/` but under a subdirectory, like `/pad/`. The same official Etherpad files do with paths, so this is just is to make it analogous. And working.
