### PR TITLE
html export (half)fix

### DIFF
--- a/export2html.js
+++ b/export2html.js
@@ -2,19 +2,26 @@
 var DatatablesRendererExport = require('ep_tables2/static/js/datatables-renderer.js');
 
 exports.getLineHTMLForExport = function (hook, context) {
+  console.debug('EP_TABLES2 PRE', context.lineContent);
   if (context.text.indexOf("data-tables") != -1) {
     var attribIndex = retrieveIndex(context.attribLine);
     var dtAttrs = context.apool.numToAttrib[attribIndex][1];
-    return DatatablesRendererExport.DatatablesRenderer.render("export", context, dtAttrs);
+    context.lineContent = DatatablesRendererExport.DatatablesRenderer.render("export", context, dtAttrs);
+    console.debug('EP_TABLES2 POST', context.lineContent);
   }
+  return true;
 };
 
 retrieveIndex = function (attribLine) {
   var arr_indices = {0 : 0, 1 : 1, 2 : 2, 3 : 3, 4 : 4, 5 : 5, 6 : 6, 7 : 7, 8 : 8, 9 : 9, 'a' : 10, 'b' : 11, 'c' : 12, 'd' : 13, 'e' : 14, 'f' : 15, 'g' : 16, 'h' : 17, 'i' : 18, 'j' : 19, 'k' : 20, 'l' : 21, 'm' : 22, 'n' : 23, 'o' : 24, 'p' : 25, 'q' : 26, 'r' : 27, 's' : 28, 't' : 29, 'u' : 30, 'v' : 31, 'w' : 32, 'x' : 33, 'y' : 34, 'z' : 35};
   var attribIndex = 0;
-
+  console.log(attribLine);
   attribLine = attribLine.split("*");
-  attribLine = attribLine[2].split('+');
+  var index = 1;
+  if (attribLine.length >= 3) {
+    index = 2;
+  }
+  attribLine = attribLine[index].split('+');
   attribLine = attribLine[0] + "";
 
   for (var i = 0; i < attribLine.length; i++) {

--- a/export2html.js
+++ b/export2html.js
@@ -2,12 +2,12 @@
 var DatatablesRendererExport = require('ep_tables2/static/js/datatables-renderer.js');
 
 exports.getLineHTMLForExport = function (hook, context) {
-  console.debug('EP_TABLES2 PRE', context.lineContent);
   if (context.text.indexOf("data-tables") != -1) {
     var attribIndex = retrieveIndex(context.attribLine);
-    var dtAttrs = context.apool.numToAttrib[attribIndex][1];
-    context.lineContent = DatatablesRendererExport.DatatablesRenderer.render("export", context, dtAttrs);
-    console.debug('EP_TABLES2 POST', context.lineContent);
+    if (attribIndex) {
+      var dtAttrs = context.apool.numToAttrib[attribIndex][1];
+      context.lineContent = DatatablesRendererExport.DatatablesRenderer.render("export", context, dtAttrs);
+    }
   }
   return true;
 };
@@ -15,7 +15,6 @@ exports.getLineHTMLForExport = function (hook, context) {
 retrieveIndex = function (attribLine) {
   var arr_indices = {0 : 0, 1 : 1, 2 : 2, 3 : 3, 4 : 4, 5 : 5, 6 : 6, 7 : 7, 8 : 8, 9 : 9, 'a' : 10, 'b' : 11, 'c' : 12, 'd' : 13, 'e' : 14, 'f' : 15, 'g' : 16, 'h' : 17, 'i' : 18, 'j' : 19, 'k' : 20, 'l' : 21, 'm' : 22, 'n' : 23, 'o' : 24, 'p' : 25, 'q' : 26, 'r' : 27, 's' : 28, 't' : 29, 'u' : 30, 'v' : 31, 'w' : 32, 'x' : 33, 'y' : 34, 'z' : 35};
   var attribIndex = 0;
-  console.log(attribLine);
   attribLine = attribLine.split("*");
   var index = 1;
   if (attribLine.length >= 3) {


### PR DESCRIPTION
This is an update to fix etherpad issues with html export and get ether/etherpad-lite#3268 merged into master. Also made some changes in the export code because it broke down eg. array didn't have element at the index 2. As it takes me too much time to go deep and fix all the issues, I made this pull request that fixes how html should be added to context.lineContent and also added some checks to prevent EP from crashing during HTML export.